### PR TITLE
#2 Implement custom JSON-RPC Errors.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,3 +3,4 @@
 Sphinx==1.3.1
 pytest==2.8.1
 pytest-cov==2.1.0
+mock==1.3.0

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,7 +9,7 @@ from tolk.exceptions import (json_rpc_error, IllegalFunction,
                              GatewayTargetDeviceFailedToRespond)
 
 
-@pytest.mark.parametrize('modbus_code,json_rpc_exception,expected', [
+@pytest.mark.parametrize('modbus_code, json_rpc_exception, expected', [
     (1, IllegalFunction, 'JsonRpcError(-32001): Function code is not valid.'),
     (2, IllegalDataAddress, 'JsonRpcError(-32002): Data address is not valid.'),
     (3, IllegalDataValue, 'JsonRpcError(-32003): Data value is not valid.'),

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,42 @@
+import pytest
+from mock import Mock
+from modbus_tk.modbus import ModbusError
+from tolk.exceptions import (json_rpc_error, IllegalFunction,
+                             IllegalDataAddress, IllegalDataValue,
+                             SlaveDeviceFailure, CommandAcknowledge,
+                             SlaveDeviceBusy, NegativeAcknowlegde,
+                             MemoryParityError, GateWayPathUnavailable,
+                             GatewayTargetDeviceFailedToRespond)
+
+
+@pytest.mark.parametrize('modbus_code,json_rpc_exception,expected', [
+    (1, IllegalFunction, 'JsonRpcError(-32001): Function code is not valid.'),
+    (2, IllegalDataAddress, 'JsonRpcError(-32002): Data address is not valid.'),
+    (3, IllegalDataValue, 'JsonRpcError(-32003): Data value is not valid.'),
+    (4, SlaveDeviceFailure, 'JsonRpcError(-32004): Slave device could not '
+                            'perform requested action.'),
+    (5, CommandAcknowledge, 'JsonRpcError(-32005): Slave device has accepted '
+                            'the request and is processing it, but a long '
+                            'duration of time will be required to do so. '
+                            'This response is returned to prevent a timeout '
+                            'error from occurring in the master.'),
+    (6, SlaveDeviceBusy, 'JsonRpcError(-32006): Slave device is busy.'),
+    (7, NegativeAcknowlegde, 'JsonRpcError(-32007): Slave device cannot perform '
+                             'the program function received in the query.'),
+    (8, MemoryParityError, 'JsonRpcError(-32008): Slave device failed to read '
+                           'extended memory or record file.'),
+    (10, GateWayPathUnavailable, 'JsonRpcError(-32010): Gateway is unable to '
+                                 'allocate an internal communication path from '
+                                 'the input port to the output port.'),
+    (11, GatewayTargetDeviceFailedToRespond, 'JsonRpcError(-32011): No response '
+                                             'obtained from the target device.')
+])
+def test_raise_modbus_json_rpc_error(modbus_code, json_rpc_exception, expected):
+    func = Mock(side_effect=ModbusError(modbus_code))
+    func.__name__ = 'function_name'
+    decorated_func = json_rpc_error(func)
+
+    with pytest.raises(json_rpc_exception) as exinfo:
+        decorated_func()
+
+    assert str(exinfo.value) == expected

--- a/tests/test_json_rpc.py
+++ b/tests/test_json_rpc.py
@@ -194,25 +194,3 @@ def test_read_and_write_coils(running_server):
     sock = get_socket(running_server.server_address)
     msg, resp = read_coils(starting_address=100, quantity=2, sock=sock)
     assert json.loads(resp) == get_expected_response(msg, [0, 1])
-
-
-def test_raise_jsonrpc_error(running_server):
-    # The actual test case:
-    #
-    # Read discrete input 100, and verify it's has returned JSONRPC error code -33002,
-    # which corresponds to IllegalDataAddress. Unless `test_read_discrete_inputs()`
-    # somehow is not executed (e.g. I commented it), it will raise an timed out error
-    sock = get_socket(running_server.server_address)
-    _, resp = read_discrete_inputs(starting_address=100, quantity=1,
-                                   sock=sock)
-    json_rpc_error_code = json.loads(resp)['error']['code']
-    assert json_rpc_error_code == -32002
-
-    # Verification test, contents copied from `test_read_discrete_inputs()`
-    # Whenever you run this, an [Errno 111] Connection refused\n
-    # will return. Do you comment either `test_read_discrete_inputs()` or this
-    # test function, no error will be raised.
-    # sock = get_socket(running_server.server_address)
-    # msg, resp = read_discrete_inputs(starting_address=0, quantity=2,
-    #                                  sock=sock)
-    # assert json.loads(resp) == get_expected_response(msg, [1, 0])

--- a/tolk/exceptions.py
+++ b/tolk/exceptions.py
@@ -1,6 +1,17 @@
+from modbus_tk.modbus import ModbusError
 from pyjsonrpc.rpcerror import jsonrpcerrors, JsonRpcError
 
 modbus_mapping = {}
+
+
+def json_rpc_error(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]
+    return wrapper
 
 
 class IllegalFunction(JsonRpcError):

--- a/tolk/exceptions.py
+++ b/tolk/exceptions.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from modbus_tk.modbus import ModbusError
 from pyjsonrpc.rpcerror import jsonrpcerrors, JsonRpcError
 
@@ -5,6 +7,9 @@ modbus_mapping = {}
 
 
 def json_rpc_error(func):
+    """ Wraps a function and raises a JSON RPC exception when a ModbusError has
+    been excepted.
+    """
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:

--- a/tolk/exceptions.py
+++ b/tolk/exceptions.py
@@ -7,8 +7,17 @@ modbus_mapping = {}
 
 
 def json_rpc_error(func):
-    """ Wraps a function and raises a JSON RPC exception when a ModbusError has
-    been excepted.
+    """ Wraps a function and raises a JSON RPC error when a ModbusError has
+    been excepted::
+
+        @json_rpc_error()
+        def modbus_request(modbus_master, slave_id, function_code,
+                           starting_address, quantity):
+
+        modbus_master.execute(int(slave_id), function_code,
+                              int(starting_address),
+                              int(quantity))
+
     """
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/tolk/exceptions.py
+++ b/tolk/exceptions.py
@@ -1,0 +1,98 @@
+from pyjsonrpc.rpcerror import jsonrpcerrors, JsonRpcError
+
+modbus_mapping = {}
+
+
+class IllegalFunction(JsonRpcError):
+    code = -32001
+    message = 'Function code is not valid.'
+
+
+jsonrpcerrors[IllegalFunction.code] = IllegalFunction
+modbus_mapping[1] = IllegalFunction
+
+
+class IllegalDataAddress(JsonRpcError):
+    code = -32002
+    message = 'Data address is not valid.'
+
+
+jsonrpcerrors[IllegalDataAddress.code] = IllegalDataAddress
+modbus_mapping[2] = IllegalDataAddress
+
+
+class IllegalDataValue(JsonRpcError):
+    code = -32003
+    message = 'Data value is not valid.'
+
+
+jsonrpcerrors[IllegalDataValue.code] = IllegalDataValue
+modbus_mapping[3] = IllegalDataValue
+
+
+class SlaveDeviceFailure(JsonRpcError):
+    code = -32004
+    message = 'Slave device could not perform requested action.'
+
+
+jsonrpcerrors[SlaveDeviceFailure.code] = SlaveDeviceFailure
+modbus_mapping[4] = SlaveDeviceFailure
+
+
+class CommandAcknowledge(JsonRpcError):
+    code = -32005
+    message = 'Slave device has accepted the request and is ' \
+              'processing it, but a long duration of time will be required to ' \
+              'do so. This response is returned to prevent a timeout error ' \
+              'from occurring in the master.'
+
+
+jsonrpcerrors[CommandAcknowledge.code] = CommandAcknowledge
+modbus_mapping[5] = CommandAcknowledge
+
+
+class SlaveDeviceBusy(JsonRpcError):
+    code = -32006
+    message = 'Slave device is busy.'
+
+
+jsonrpcerrors[SlaveDeviceBusy.code] = SlaveDeviceBusy
+modbus_mapping[6] = SlaveDeviceBusy
+
+
+class NegativeAcknowlegde(JsonRpcError):
+    code = -32007
+    message = 'Slave device cannot perform the program function received in the ' \
+              'query.'
+
+
+jsonrpcerrors[NegativeAcknowlegde.code] = NegativeAcknowlegde
+modbus_mapping[7] = NegativeAcknowlegde
+
+
+class MemoryParityError(JsonRpcError):
+    code = -32008
+    message = 'Slave device failed to read extended memory or record file.'
+
+
+jsonrpcerrors[MemoryParityError.code] = MemoryParityError
+modbus_mapping[8] = MemoryParityError
+
+
+class GateWayPathUnavailable(JsonRpcError):
+    code = -32010
+    message = 'Gateway is unable to allocate an internal communication path from ' \
+              'the input port to the output port.'
+
+
+jsonrpcerrors[GateWayPathUnavailable.code] = GateWayPathUnavailable
+modbus_mapping[10] = GateWayPathUnavailable
+
+
+class GatewayTargetDeviceFailedToRespond(JsonRpcError):
+    code = -32011
+    message = 'No response obtained from the target device.'
+
+
+jsonrpcerrors[GatewayTargetDeviceFailedToRespond.code] = GatewayTargetDeviceFailedToRespond
+modbus_mapping[11] = GatewayTargetDeviceFailedToRespond

--- a/tolk/json_rpc.py
+++ b/tolk/json_rpc.py
@@ -4,9 +4,12 @@ from modbus_tk.defines import (READ_COILS, READ_DISCRETE_INPUTS,
                                WRITE_SINGLE_COIL, WRITE_SINGLE_REGISTER,
                                WRITE_MULTIPLE_COILS, WRITE_MULTIPLE_REGISTERS)
 
+from modbus_tk.modbus import ModbusError
+
+from tolk.exceptions import modbus_mapping
+
 
 class Dispatcher(JsonRpc):
-
     def __init__(self, modbus_master):
         self.modbus_master = modbus_master
 
@@ -20,22 +23,29 @@ class Dispatcher(JsonRpc):
         :param quantity: Number of coils to read.
         :param slave: Number with Slave id, default 1.
         """
-        return self.modbus_master.execute(int(slave_id), READ_COILS,
-                                          int(starting_address),
-                                          int(quantity))
+        try:
+            return self.modbus_master.execute(int(slave_id), READ_COILS,
+                                              int(starting_address),
+                                              int(quantity))
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def read_discrete_inputs(self, starting_address, quantity,
                              slave_id=1):
-        """ Execute Modbus function code 02: read status of discreate inputs.
+        """ Execute Modbus function code 02: read status of discrete inputs.
 
         :param starting_address: Number of starting address.
         :param quantity: Number of discrete inputs to read.
         :param slave: Number with Slave id, default 1.
         """
-        return self.modbus_master.execute(int(slave_id), READ_DISCRETE_INPUTS,
-                                          int(starting_address),
-                                          int(quantity))
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              READ_DISCRETE_INPUTS,
+                                              int(starting_address),
+                                              int(quantity))
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def read_holding_registers(self, starting_address, quantity,
@@ -47,9 +57,13 @@ class Dispatcher(JsonRpc):
         :param quantity: Number of holding registers to read.
         :param slave: Number with Slave id, default 1.
         """
-        return self.modbus_master.execute(int(slave_id),
-                                          READ_HOLDING_REGISTERS,
-                                          int(starting_address), int(quantity))
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              READ_HOLDING_REGISTERS,
+                                              int(starting_address),
+                                              int(quantity))
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def read_input_registers(self, starting_address, quantity,
@@ -61,9 +75,13 @@ class Dispatcher(JsonRpc):
         :param quantity: Number of input registers to read.
         :param slave: Number with Slave id, default 1.
         """
-        return self.modbus_master.execute(int(slave_id),
-                                          READ_INPUT_REGISTERS,
-                                          int(starting_address), int(quantity))
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              READ_INPUT_REGISTERS,
+                                              int(starting_address),
+                                              int(quantity))
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def write_single_coil(self, address, value, slave_id=1):
@@ -73,9 +91,12 @@ class Dispatcher(JsonRpc):
         :param value: Value to write to coil.
         :param slave: Number with Slave id, default 1.
         """
-        return self.modbus_master.execute(int(slave_id),
-                                          WRITE_SINGLE_COIL, int(address),
-                                          output_value=int(value))
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              WRITE_SINGLE_COIL, int(address),
+                                              output_value=int(value))
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def write_single_register(self, address, value, slave_id=1):
@@ -86,9 +107,12 @@ class Dispatcher(JsonRpc):
         :param value: Value to write to holding register.
         :param slave: Number with Slave id, default 1.
         """
-        return self.modbus_master.execute(int(slave_id),
-                                          WRITE_SINGLE_REGISTER, int(address),
-                                          output_value=int(value))
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              WRITE_SINGLE_REGISTER, int(address),
+                                              output_value=int(value))
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def write_multiple_coils(self, starting_address, values,
@@ -106,10 +130,13 @@ class Dispatcher(JsonRpc):
         :param slave: Number with Slave id, default 1.
         """
         values = [int(v) for v in values]
-        return self.modbus_master.execute(int(slave_id),
-                                          WRITE_MULTIPLE_COILS,
-                                          int(starting_address),
-                                          output_value=values)
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              WRITE_MULTIPLE_COILS,
+                                              int(starting_address),
+                                              output_value=values)
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()
 
     @rpcmethod
     def write_multiple_registers(self, starting_address, values,
@@ -127,7 +154,10 @@ class Dispatcher(JsonRpc):
         :param slave: Number with Slave id, default 1.
         """
         values = [int(v) for v in values]
-        return self.modbus_master.execute(int(slave_id),
-                                          WRITE_MULTIPLE_REGISTERS,
-                                          int(starting_address),
-                                          output_value=values)
+        try:
+            return self.modbus_master.execute(int(slave_id),
+                                              WRITE_MULTIPLE_REGISTERS,
+                                              int(starting_address),
+                                              output_value=values)
+        except ModbusError as e:
+            raise modbus_mapping[e.get_exception_code()]()

--- a/tolk/json_rpc.py
+++ b/tolk/json_rpc.py
@@ -1,12 +1,9 @@
-from pyjsonrpc import JsonRpc, rpcmethod
 from modbus_tk.defines import (READ_COILS, READ_DISCRETE_INPUTS,
                                READ_HOLDING_REGISTERS, READ_INPUT_REGISTERS,
                                WRITE_SINGLE_COIL, WRITE_SINGLE_REGISTER,
                                WRITE_MULTIPLE_COILS, WRITE_MULTIPLE_REGISTERS)
-
-from modbus_tk.modbus import ModbusError
-
-from tolk.exceptions import modbus_mapping
+from pyjsonrpc import JsonRpc, rpcmethod
+from tolk.exceptions import json_rpc_error
 
 
 class Dispatcher(JsonRpc):
@@ -16,6 +13,7 @@ class Dispatcher(JsonRpc):
         super(JsonRpc, self).__init__()
 
     @rpcmethod
+    @json_rpc_error
     def read_coils(self, starting_address, quantity, slave_id=1):
         """ Execute Modbus function code 01: read status of coils.
 
@@ -23,33 +21,26 @@ class Dispatcher(JsonRpc):
         :param quantity: Number of coils to read.
         :param slave: Number with Slave id, default 1.
         """
-        try:
-            return self.modbus_master.execute(int(slave_id), READ_COILS,
-                                              int(starting_address),
-                                              int(quantity))
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id), READ_COILS,
+                                          int(starting_address),
+                                          int(quantity))
 
     @rpcmethod
-    def read_discrete_inputs(self, starting_address, quantity,
-                             slave_id=1):
+    @json_rpc_error
+    def read_discrete_inputs(self, starting_address, quantity, slave_id=1):
         """ Execute Modbus function code 02: read status of discrete inputs.
 
         :param starting_address: Number of starting address.
         :param quantity: Number of discrete inputs to read.
         :param slave: Number with Slave id, default 1.
         """
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              READ_DISCRETE_INPUTS,
-                                              int(starting_address),
-                                              int(quantity))
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id), READ_DISCRETE_INPUTS,
+                                          int(starting_address),
+                                          int(quantity))
 
     @rpcmethod
-    def read_holding_registers(self, starting_address, quantity,
-                               slave_id=1):
+    @json_rpc_error
+    def read_holding_registers(self, starting_address, quantity, slave_id=1):
         """ Execute Modbus function code 03: read contents of contiguous block
         of holding registers.
 
@@ -57,17 +48,13 @@ class Dispatcher(JsonRpc):
         :param quantity: Number of holding registers to read.
         :param slave: Number with Slave id, default 1.
         """
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              READ_HOLDING_REGISTERS,
-                                              int(starting_address),
-                                              int(quantity))
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id), READ_HOLDING_REGISTERS,
+                                          int(starting_address),
+                                          int(quantity))
 
     @rpcmethod
-    def read_input_registers(self, starting_address, quantity,
-                             slave_id=1):
+    @json_rpc_error
+    def read_input_registers(self, starting_address, quantity, slave_id=1):
         """ Execute Modbus function code 04: read contents of contiguous block
         of input registers.
 
@@ -75,15 +62,12 @@ class Dispatcher(JsonRpc):
         :param quantity: Number of input registers to read.
         :param slave: Number with Slave id, default 1.
         """
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              READ_INPUT_REGISTERS,
-                                              int(starting_address),
-                                              int(quantity))
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id), READ_INPUT_REGISTERS,
+                                          int(starting_address),
+                                          int(quantity))
 
     @rpcmethod
+    @json_rpc_error
     def write_single_coil(self, address, value, slave_id=1):
         """ Execute Modbus function code 05: write value to single coil.
 
@@ -91,14 +75,12 @@ class Dispatcher(JsonRpc):
         :param value: Value to write to coil.
         :param slave: Number with Slave id, default 1.
         """
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              WRITE_SINGLE_COIL, int(address),
-                                              output_value=int(value))
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id), WRITE_SINGLE_COIL,
+                                          int(address),
+                                          output_value=int(value))
 
     @rpcmethod
+    @json_rpc_error
     def write_single_register(self, address, value, slave_id=1):
         """ Execute Modbus function code 06: write value to single holding
         register.
@@ -107,16 +89,13 @@ class Dispatcher(JsonRpc):
         :param value: Value to write to holding register.
         :param slave: Number with Slave id, default 1.
         """
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              WRITE_SINGLE_REGISTER, int(address),
-                                              output_value=int(value))
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id),
+                                          WRITE_SINGLE_REGISTER, int(address),
+                                          output_value=int(value))
 
     @rpcmethod
-    def write_multiple_coils(self, starting_address, values,
-                             slave_id=1):
+    @json_rpc_error
+    def write_multiple_coils(self, starting_address, values, slave_id=1):
         """ Execute Modbus function code 15: write sequence of values to a
         contiguous block of coils.
 
@@ -130,17 +109,14 @@ class Dispatcher(JsonRpc):
         :param slave: Number with Slave id, default 1.
         """
         values = [int(v) for v in values]
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              WRITE_MULTIPLE_COILS,
-                                              int(starting_address),
-                                              output_value=values)
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id),
+                                          WRITE_MULTIPLE_COILS,
+                                          int(starting_address),
+                                          output_value=values)
 
     @rpcmethod
-    def write_multiple_registers(self, starting_address, values,
-                                 slave_id=1):
+    @json_rpc_error
+    def write_multiple_registers(self, starting_address, values, slave_id=1):
         """ Execute Modbus function code 16: write sequence of values to a
         contiguous block of holding registers.
 
@@ -154,10 +130,7 @@ class Dispatcher(JsonRpc):
         :param slave: Number with Slave id, default 1.
         """
         values = [int(v) for v in values]
-        try:
-            return self.modbus_master.execute(int(slave_id),
-                                              WRITE_MULTIPLE_REGISTERS,
-                                              int(starting_address),
-                                              output_value=values)
-        except ModbusError as e:
-            raise modbus_mapping[e.get_exception_code()]()
+        return self.modbus_master.execute(int(slave_id),
+                                          WRITE_MULTIPLE_REGISTERS,
+                                          int(starting_address),
+                                          output_value=values)

--- a/tolk/json_rpc.py
+++ b/tolk/json_rpc.py
@@ -76,8 +76,7 @@ class Dispatcher(JsonRpc):
         :param slave: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id), WRITE_SINGLE_COIL,
-                                          int(address),
-                                          output_value=int(value))
+                                          int(address), output_value=int(value))
 
     @rpcmethod
     @json_rpc_error

--- a/tolk/json_rpc.py
+++ b/tolk/json_rpc.py
@@ -19,7 +19,7 @@ class Dispatcher(JsonRpc):
 
         :param starting_address: Number of starting address.
         :param quantity: Number of coils to read.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id), READ_COILS,
                                           int(starting_address),
@@ -32,7 +32,7 @@ class Dispatcher(JsonRpc):
 
         :param starting_address: Number of starting address.
         :param quantity: Number of discrete inputs to read.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id), READ_DISCRETE_INPUTS,
                                           int(starting_address),
@@ -46,7 +46,7 @@ class Dispatcher(JsonRpc):
 
         :param starting_address: Number of starting address.
         :param quantity: Number of holding registers to read.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id), READ_HOLDING_REGISTERS,
                                           int(starting_address),
@@ -60,7 +60,7 @@ class Dispatcher(JsonRpc):
 
         :param starting_address: Number of starting address.
         :param quantity: Number of input registers to read.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id), READ_INPUT_REGISTERS,
                                           int(starting_address),
@@ -73,7 +73,7 @@ class Dispatcher(JsonRpc):
 
         :param address: Address of coil.
         :param value: Value to write to coil.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id), WRITE_SINGLE_COIL,
                                           int(address), output_value=int(value))
@@ -86,7 +86,7 @@ class Dispatcher(JsonRpc):
 
         :param address: Address of holding register.
         :param value: Value to write to holding register.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         return self.modbus_master.execute(int(slave_id),
                                           WRITE_SINGLE_REGISTER, int(address),
@@ -101,11 +101,11 @@ class Dispatcher(JsonRpc):
         .. note:: This method doesn't follow the interface as described in the
             Modbus specification. The specification describes 2 extra
             'parameters': quantity of outputs and byte count. Tolk will derive
-            them from paramater `values`.
+            them from parameter `values`.
 
         :param starting_address: Number of starting address.
         :param values: List with values.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         values = [int(v) for v in values]
         return self.modbus_master.execute(int(slave_id),
@@ -122,11 +122,11 @@ class Dispatcher(JsonRpc):
         .. note:: This method doesn't follow the interface as described in the
             Modbus specification. The specification describes 2 extra
             'parameters': quantity of outputs and byte count. Tolk will derive
-            them from paramater `values`.
+            them from parameter `values`.
 
         :param starting_address: Number of starting address.
         :param values: List with values to write.
-        :param slave: Number with Slave id, default 1.
+        :param slave_id: Number with Slave id, default 1.
         """
         values = [int(v) for v in values]
         return self.modbus_master.execute(int(slave_id),


### PR DESCRIPTION
This pull request adds custom JSON-RPC errors which formats Modbus errors into proper JSON-RPC errors. Although the issue (#2) mentioned only those modbus errors defined by `modbus-tk`, all of the official Modbus errors are mapped to custom JSON-RPC errors. In the case, whenever a modbus server returns an error, the JSON-RPC response will not contain an ugly stack trace.  

This closes #2
